### PR TITLE
setup.py requires name='desreo'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as file:
 version = imp.load_source('desreo.version', 'desreo/version.py')                         
                                                                                                              
 setup(                                                                                                       
-    name='',                                                                                 
+    name='desreo',
     version=version.version,                                                                                 
     description='',
     author='',                                                                                  


### PR DESCRIPTION
A little fix for python 3.11